### PR TITLE
Add --no-verbose as a default flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Enable or disable fail if results were found'
     required: false
     default: 'false'
+  no-verbose:
+    description: 'Enable or disable progress bar'
+    required: false
+    default: 'true'
 
 runs:
   using: 'docker'
@@ -27,6 +31,7 @@ runs:
     - ${{ inputs.output-type }}
     - ${{ inputs.output-file }}
     - ${{ inputs.fail-on-result }}
+    - ${{ inputs.no-verbose }}
 
 branding:
  color: gray-dark

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,10 @@ inputs:
     description: 'Enable or disable fail if results were found'
     required: false
     default: 'false'
-  no-verbose:
-    description: 'Enable or disable progress bar'
+  verbose:
+    description: 'Enable or disable printing the progress bar'
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: 'docker'
@@ -31,7 +31,7 @@ runs:
     - ${{ inputs.output-type }}
     - ${{ inputs.output-file }}
     - ${{ inputs.fail-on-result }}
-    - ${{ inputs.no-verbose }}
+    - ${{ inputs.verbose }}
 
 branding:
  color: gray-dark

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,10 @@ output_type="$2"
 output_file="$3"
 fail_on_result="$4"
 
-if [[ $no_verbose == "true" ]]; then
-    no_verbose_cmd="--no-verbose"
+if [[ $verbose == "true" ]]; then
+    verbose_cmd="--verbose"
 else
-    no_verbose_cmd=""
+    verbose_cmd="--no-verbose"
 fi
 
 if [[ $fail_on_result == "true" ]]; then
@@ -25,4 +25,4 @@ fi
 
 cd /github/workspace/
 clj-holmes fetch-rules -r "$rules_repository"
-clj-holmes scan -p . $fail_on_result_cmd $no_verbose_cmd $output_cmd
+clj-holmes scan -p . $fail_on_result_cmd $verbose_cmd $output_cmd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,12 @@ output_type="$2"
 output_file="$3"
 fail_on_result="$4"
 
+if [[ $no_verbose == "true" ]]; then
+    no_verbose_cmd="--no-verbose"
+else
+    no_verbose_cmd=""
+fi
+
 if [[ $fail_on_result == "true" ]]; then
   fail_on_result_cmd="--fail-on-result";
 else
@@ -19,4 +25,4 @@ fi
 
 cd /github/workspace/
 clj-holmes fetch-rules -r "$rules_repository"
-clj-holmes scan -p . $fail_on_result_cmd $output_cmd
+clj-holmes scan -p . $fail_on_result_cmd $no_verbose_cmd $output_cmd


### PR DESCRIPTION
This PR makes running clj-holmes with the `--no-verbose` flag the default. This avoids some issues with progrock progress bar.