### PR TITLE
Fix `verbose` and `path` inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It's also possible to specify the following:
 - output-type (json, sarif or stdout) [Default: sarif]
 - output-file [Default: clj_holmes_scan_results.txt]
 - fail-on-result (true or false) [Default: false]
+- verbose (true or false) [Default: false]
+- path, absolute or relative path to scan [Default: (empty -- scans current working directory)]
 
 ```
 - name: Scan

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,8 @@ rules_repository="$1"
 output_type="$2"
 output_file="$3"
 fail_on_result="$4"
-path="$5"
+verbose="$5"
+path="$6"
 
 if [[ -d "${path}" ]]; then
   cd "${path}"


### PR DESCRIPTION
Prior to this change, the value from the `verbose` GitHub action input was errantly treated as `$path` in `entrypoint.sh` and the `path` input was unused.

This was caused by a mismatch between a `args` in `action.yml` and the positional parameters expected by `entrypoint.sh`.